### PR TITLE
Feature/quorum queue

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -19,7 +19,8 @@ func main() {
 		WithMaxLength(100_000).
 		WithRetry(time.Second*10, 3).
 		WithDQL().
-		WithDLQMaxLength(10_000)
+		WithDLQMaxLength(10_000).
+		Quorum()
 
 	topology := bunmq.
 		NewTopology("my-app", "amqp://guest:guest@localhost:5672/").

--- a/queue.go
+++ b/queue.go
@@ -14,6 +14,7 @@ import (
 // exclusivity, TTL, DLQ (Dead Letter Queue), and retry mechanisms.
 type QueueDefinition struct {
 	name             string
+	quorum           bool
 	durable          bool
 	delete           bool
 	exclusive        bool
@@ -108,6 +109,19 @@ func (q *QueueDefinition) WithRetry(ttl time.Duration, retries int64) *QueueDefi
 	q.retryTTL = ttl
 	q.retries = retries
 	return q
+}
+
+func (q *QueueDefinition) Quorum() *QueueDefinition {
+	q.quorum = true
+	return q
+}
+
+func (q *QueueDefinition) queueType() string {
+	if q.quorum {
+		return "quorum"
+	}
+
+	return "classic"
 }
 
 // Name returns the name of the queue.

--- a/queue_test.go
+++ b/queue_test.go
@@ -196,9 +196,9 @@ func TestQueueDefinition_WithTTL(t *testing.T) {
 
 func TestQueueDefinition_WithDQL(t *testing.T) {
 	tests := []struct {
-		name          string
-		queueName     string
-		expectedDLQ   string
+		name        string
+		queueName   string
+		expectedDLQ string
 	}{
 		{
 			name:        "basic DLQ",
@@ -416,7 +416,7 @@ func TestQueueDefinition_FluentChaining(t *testing.T) {
 		Delete(false).
 		Exclusive(false).
 		WithMaxLength(10000).
-		WithTTL(5 * time.Minute).
+		WithTTL(5*time.Minute).
 		WithDQL().
 		WithDLQMaxLength(1000).
 		WithRetry(30*time.Second, 3)
@@ -447,5 +447,24 @@ func TestQueueDefinition_FluentChaining(t *testing.T) {
 	}
 	if !q.withRetry || q.retryTTL != 30*time.Second || q.retries != 3 {
 		t.Error("Chained queue should have retry enabled with 30s TTL and 3 retries")
+	}
+}
+
+func TestQueueDefinition_Quorum(t *testing.T) {
+	// Default should be classic
+	q := NewQueue("test-quorum")
+	if got := q.queueType(); got != "classic" {
+		t.Errorf("default queueType() = %v, want classic", got)
+	}
+
+	// After calling Quorum(), queueType should be quorum
+	q.Quorum()
+	if got := q.queueType(); got != "quorum" {
+		t.Errorf("after Quorum(), queueType() = %v, want quorum", got)
+	}
+
+	// Ensure chaining returns the same instance
+	if q2 := q.Quorum(); q2 != q {
+		t.Error("Quorum() should return the same QueueDefinition instance for chaining")
 	}
 }

--- a/topology.go
+++ b/topology.go
@@ -214,6 +214,7 @@ func (t *topology) declareQueues() error {
 				"x-dead-letter-routing-key": queue.name,
 				"x-message-ttl":             queue.retryTTL.Milliseconds(),
 				"x-retry-count":             queue.retries,
+				"x-queue-type":              queue.queueType(),
 			}); err != nil {
 				return err
 			}
@@ -226,6 +227,7 @@ func (t *topology) declareQueues() error {
 			amqpDlqDeclarationOpts = amqp.Table{
 				"x-dead-letter-exchange":    "",
 				"x-dead-letter-routing-key": queue.RetryName(),
+				"x-queue-type":              queue.queueType(),
 			}
 		}
 
@@ -233,6 +235,7 @@ func (t *topology) declareQueues() error {
 			amqpDlqDeclarationOpts = amqp.Table{
 				"x-dead-letter-exchange":    "",
 				"x-dead-letter-routing-key": queue.DLQName(),
+				"x-queue-type":              queue.queueType(),
 			}
 		}
 


### PR DESCRIPTION
This pull request introduces support for quorum queues in the queue definition and topology logic, allowing users to opt-in to RabbitMQ's quorum queue type via a fluent API. The changes include updates to the queue definition structure, the addition of the `Quorum()` method, propagation of the queue type to queue declarations, and corresponding unit tests.

**Quorum queue support:**

* Added a `quorum` boolean field to the `QueueDefinition` struct and implemented the `Quorum()` method to enable quorum queues with fluent chaining. Also added a `queueType()` method to return either `"quorum"` or `"classic"` based on the queue configuration. (`queue.go`) [[1]](diffhunk://#diff-979cedf61ccaba8f637a393ae99a88eae86eeb9817cab20e334a25a825913695R17) [[2]](diffhunk://#diff-979cedf61ccaba8f637a393ae99a88eae86eeb9817cab20e334a25a825913695R114-R126)

* Updated queue declaration logic to include the `x-queue-type` property in AMQP table options, ensuring the correct queue type is set for main, retry, and DLQ queues. (`topology.go`) [[1]](diffhunk://#diff-d3e460527dea0142094626ffbc7898d5fc8af39967391a7c70e0d23c2d6a098aR217) [[2]](diffhunk://#diff-d3e460527dea0142094626ffbc7898d5fc8af39967391a7c70e0d23c2d6a098aR230-R238)

**API and usage improvements:**

* Exposed the `Quorum()` method in the queue configuration chain, allowing users to specify quorum queues in their application setup. (`examples/main.go`)

**Testing:**

* Added unit tests to verify the default queue type, the effect of calling `Quorum()`, and the fluent chaining behavior of the new method. (`queue_test.go`)