### PR TITLE
Quorum

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -19,8 +19,7 @@ func main() {
 		WithMaxLength(100_000).
 		WithRetry(time.Second*10, 3).
 		WithDQL().
-		WithDLQMaxLength(10_000).
-		Quorum()
+		WithDLQMaxLength(10_000)
 
 	topology := bunmq.
 		NewTopology("my-app", "amqp://guest:guest@localhost:5672/").

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	go.opentelemetry.io/auto/sdk v1.2.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-go.opentelemetry.io/auto/sdk v1.2.0 h1:YpRtUFjvhSymycLS2T81lT6IGhcUP+LUPtv0iv1N8bM=
-go.opentelemetry.io/auto/sdk v1.2.0/go.mod h1:1deq2zL7rwjwC8mR7XgY2N+tlIl6pjmEUoLDENMEzwk=
+go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
+go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
 go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
 go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=


### PR DESCRIPTION
This pull request contains minor updates to the `examples/main.go` and `go.mod` files. The changes include a dependency version bump and a small adjustment to the message queue configuration.

Dependency update:

* Upgraded `go.opentelemetry.io/auto/sdk` from version `v1.2.0` to `v1.2.1` in `go.mod` for improved stability and potential bug fixes.

Configuration adjustment:

* In `examples/main.go`, removed the call to `Quorum()` from the message queue builder chain, leaving only `WithDLQMaxLength(10_000)`, which may affect message durability or queue behavior.