### PR TITLE
Develop

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -19,7 +19,8 @@ func main() {
 		WithMaxLength(100_000).
 		WithRetry(time.Second*10, 3).
 		WithDQL().
-		WithDLQMaxLength(10_000)
+		WithDLQMaxLength(10_000).
+		Quorum()
 
 	topology := bunmq.
 		NewTopology("my-app", "amqp://guest:guest@localhost:5672/").

--- a/examples/main.go
+++ b/examples/main.go
@@ -19,8 +19,7 @@ func main() {
 		WithMaxLength(100_000).
 		WithRetry(time.Second*10, 3).
 		WithDQL().
-		WithDLQMaxLength(10_000).
-		Quorum()
+		WithDLQMaxLength(10_000)
 
 	topology := bunmq.
 		NewTopology("my-app", "amqp://guest:guest@localhost:5672/").

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	go.opentelemetry.io/auto/sdk v1.2.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-go.opentelemetry.io/auto/sdk v1.2.0 h1:YpRtUFjvhSymycLS2T81lT6IGhcUP+LUPtv0iv1N8bM=
-go.opentelemetry.io/auto/sdk v1.2.0/go.mod h1:1deq2zL7rwjwC8mR7XgY2N+tlIl6pjmEUoLDENMEzwk=
+go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
+go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
 go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
 go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=

--- a/queue.go
+++ b/queue.go
@@ -14,6 +14,7 @@ import (
 // exclusivity, TTL, DLQ (Dead Letter Queue), and retry mechanisms.
 type QueueDefinition struct {
 	name             string
+	quorum           bool
 	durable          bool
 	delete           bool
 	exclusive        bool
@@ -108,6 +109,19 @@ func (q *QueueDefinition) WithRetry(ttl time.Duration, retries int64) *QueueDefi
 	q.retryTTL = ttl
 	q.retries = retries
 	return q
+}
+
+func (q *QueueDefinition) Quorum() *QueueDefinition {
+	q.quorum = true
+	return q
+}
+
+func (q *QueueDefinition) queueType() string {
+	if q.quorum {
+		return "quorum"
+	}
+
+	return "classic"
 }
 
 // Name returns the name of the queue.

--- a/queue_test.go
+++ b/queue_test.go
@@ -196,9 +196,9 @@ func TestQueueDefinition_WithTTL(t *testing.T) {
 
 func TestQueueDefinition_WithDQL(t *testing.T) {
 	tests := []struct {
-		name          string
-		queueName     string
-		expectedDLQ   string
+		name        string
+		queueName   string
+		expectedDLQ string
 	}{
 		{
 			name:        "basic DLQ",
@@ -416,7 +416,7 @@ func TestQueueDefinition_FluentChaining(t *testing.T) {
 		Delete(false).
 		Exclusive(false).
 		WithMaxLength(10000).
-		WithTTL(5 * time.Minute).
+		WithTTL(5*time.Minute).
 		WithDQL().
 		WithDLQMaxLength(1000).
 		WithRetry(30*time.Second, 3)
@@ -447,5 +447,24 @@ func TestQueueDefinition_FluentChaining(t *testing.T) {
 	}
 	if !q.withRetry || q.retryTTL != 30*time.Second || q.retries != 3 {
 		t.Error("Chained queue should have retry enabled with 30s TTL and 3 retries")
+	}
+}
+
+func TestQueueDefinition_Quorum(t *testing.T) {
+	// Default should be classic
+	q := NewQueue("test-quorum")
+	if got := q.queueType(); got != "classic" {
+		t.Errorf("default queueType() = %v, want classic", got)
+	}
+
+	// After calling Quorum(), queueType should be quorum
+	q.Quorum()
+	if got := q.queueType(); got != "quorum" {
+		t.Errorf("after Quorum(), queueType() = %v, want quorum", got)
+	}
+
+	// Ensure chaining returns the same instance
+	if q2 := q.Quorum(); q2 != q {
+		t.Error("Quorum() should return the same QueueDefinition instance for chaining")
 	}
 }

--- a/topology.go
+++ b/topology.go
@@ -214,6 +214,7 @@ func (t *topology) declareQueues() error {
 				"x-dead-letter-routing-key": queue.name,
 				"x-message-ttl":             queue.retryTTL.Milliseconds(),
 				"x-retry-count":             queue.retries,
+				"x-queue-type":              queue.queueType(),
 			}); err != nil {
 				return err
 			}
@@ -226,6 +227,7 @@ func (t *topology) declareQueues() error {
 			amqpDlqDeclarationOpts = amqp.Table{
 				"x-dead-letter-exchange":    "",
 				"x-dead-letter-routing-key": queue.RetryName(),
+				"x-queue-type":              queue.queueType(),
 			}
 		}
 
@@ -233,6 +235,7 @@ func (t *topology) declareQueues() error {
 			amqpDlqDeclarationOpts = amqp.Table{
 				"x-dead-letter-exchange":    "",
 				"x-dead-letter-routing-key": queue.DLQName(),
+				"x-queue-type":              queue.queueType(),
 			}
 		}
 


### PR DESCRIPTION
This pull request introduces support for RabbitMQ quorum queues, allowing queues to be explicitly configured as quorum type instead of the classic type. The update adds a new `quorum` property and related methods to the `QueueDefinition` struct, ensures the queue type is set in queue declaration options, and includes tests for the new functionality.

**Quorum queue support:**

* Added a `quorum` field to the `QueueDefinition` struct and a `Quorum()` method to enable fluent configuration of quorum queues. Also added a `queueType()` method to return either `"quorum"` or `"classic"` based on configuration. [[1]](diffhunk://#diff-979cedf61ccaba8f637a393ae99a88eae86eeb9817cab20e334a25a825913695R17) [[2]](diffhunk://#diff-979cedf61ccaba8f637a393ae99a88eae86eeb9817cab20e334a25a825913695R114-R126)

**Queue declaration enhancements:**

* Modified queue and DLQ declaration logic in `topology.go` to include the `x-queue-type` property based on the queue type, ensuring correct queue type is set when declaring queues with RabbitMQ. [[1]](diffhunk://#diff-d3e460527dea0142094626ffbc7898d5fc8af39967391a7c70e0d23c2d6a098aR217) [[2]](diffhunk://#diff-d3e460527dea0142094626ffbc7898d5fc8af39967391a7c70e0d23c2d6a098aR230-R238)

**Testing:**

* Added a new test `TestQueueDefinition_Quorum` to verify default behavior, correct switching to quorum type, and method chaining for the `Quorum()` method.

**Dependency update:**

* Updated the `go.opentelemetry.io/auto/sdk` dependency from version `v1.2.0` to `v1.2.1` in `go.mod`.